### PR TITLE
Do not copy marks when creatig a child node

### DIFF
--- a/src/game_tree/matrix.cpp
+++ b/src/game_tree/matrix.cpp
@@ -46,7 +46,7 @@ Matrix::Matrix(const Matrix &m, bool cleanup)
     unsigned short mask = stoneWhite | stoneBlack;
     if (!cleanup)
         mask |= markAll;
-    mask |= (~markKoMarker);
+    mask &= (~markKoMarker);
     for (int i=0; i<size*size; ++i)
         matrix[i] = m.matrix[i] & mask;
 }


### PR DESCRIPTION
Resolves some rendering problems e.g. in Kogo's Joseki Dictionary
